### PR TITLE
fix engine requirement

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
       "devDependencies": {
         "eslint": "8.39.0",
         "eslint-config-prettier": "8.8.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,6 @@
     "eslint-config-prettier": "8.8.0"
   },
   "engines": {
-    "node": 12
+    "node": ">=12"
   }
 }


### PR DESCRIPTION
This removes warning if using node newer than 12:
```
npm install
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'mmm-plex-recently-added@1.0.0',
npm WARN EBADENGINE   required: { node: 12 },
npm WARN EBADENGINE   current: { node: 'v18.15.0', npm: '9.5.0' }
npm WARN EBADENGINE }
```